### PR TITLE
Fix note-transposition, channel-overflow crash, transmitter live-play relay, and other 1.21.1-neo bugs

### DIFF
--- a/src/main/java/io/github/tofodroid/com/sun/media/sound/SoftMainMixer.java
+++ b/src/main/java/io/github/tofodroid/com/sun/media/sound/SoftMainMixer.java
@@ -440,10 +440,17 @@ public final class SoftMainMixer {
                 }
 
                 if(data != null) {
-                    int status = 0;
-                    if (data.length > 0)
-                        status = data[0] & 0xFF;
-                    int ch = (status & 0x0F);
+                    int ch;
+                    if(entry.getValue() instanceof ShortMessage) {
+                        // Use getChannel() rather than the raw status byte so channels beyond
+                        // the standard 0-15 range (see ExtendedChannelShortMessage) resolve correctly.
+                        ch = ((ShortMessage)entry.getValue()).getChannel();
+                    } else {
+                        int status = 0;
+                        if (data.length > 0)
+                            status = data[0] & 0xFF;
+                        ch = (status & 0x0F);
+                    }
 
                     if(ch == channel) {
                         try {

--- a/src/main/java/io/github/tofodroid/mods/mimi/client/gui/GuiInstrument.java
+++ b/src/main/java/io/github/tofodroid/mods/mimi/client/gui/GuiInstrument.java
@@ -743,11 +743,13 @@ public class GuiInstrument extends BaseGui {
     }
 
     private String buildNoteIdString() {
-        String result = "";    
-        result += noteLetterFromNum(visibleNoteShift % 7) + Integer.valueOf(visibleNoteShift / 7).toString();
-        result += "," + noteLetterFromNum((visibleNoteShift+10) % 7) + Integer.valueOf((visibleNoteShift+10) / 7).toString();
-        result += " | " + noteLetterFromNum((visibleNoteShift+11) % 7) + Integer.valueOf((visibleNoteShift+11) / 7).toString();
-        result += "," + noteLetterFromNum((visibleNoteShift+21) % 7) + Integer.valueOf((visibleNoteShift+21) / 7).toString();
+        String result = "";
+        // -1 on each octave number so it matches scientific pitch notation (middle C = C4, MIDI note 60),
+        // consistent with MidiNbtDataUtils#getMidiNoteAsString / getFilteredNotesAsString.
+        result += noteLetterFromNum(visibleNoteShift % 7) + Integer.valueOf(visibleNoteShift / 7 - 1).toString();
+        result += "," + noteLetterFromNum((visibleNoteShift+10) % 7) + Integer.valueOf((visibleNoteShift+10) / 7 - 1).toString();
+        result += " | " + noteLetterFromNum((visibleNoteShift+11) % 7) + Integer.valueOf((visibleNoteShift+11) / 7 - 1).toString();
+        result += "," + noteLetterFromNum((visibleNoteShift+21) % 7) + Integer.valueOf((visibleNoteShift+21) / 7 - 1).toString();
         return result;
     }
 

--- a/src/main/java/io/github/tofodroid/mods/mimi/client/midi/synth/AMIMISynth.java
+++ b/src/main/java/io/github/tofodroid/mods/mimi/client/midi/synth/AMIMISynth.java
@@ -48,7 +48,7 @@ public abstract class AMIMISynth<T extends MIMIChannel> implements AutoCloseable
         } catch(Exception e) {
             MIMIMod.LOGGER.error("Failed to initialize MIDI Synthesizer: ", e);
             this.internalSynth = null;
-            this.internalSynth.getVoiceStatus();
+            this.internalSynthReceiver = null;
         }
 
         Builder<T> builder = ImmutableList.builder();
@@ -112,7 +112,7 @@ public abstract class AMIMISynth<T extends MIMIChannel> implements AutoCloseable
         if(channel != null) {
             try {
                 channel.noteOn(message.pos);
-                this.internalSynthReceiver.send(new ShortMessage(ShortMessage.NOTE_ON, channel.getChannelNumber(), message.data1, message.data2), getSynthEventTimestamp(timestamp));
+                this.internalSynthReceiver.send(new ExtendedChannelShortMessage(ShortMessage.NOTE_ON, channel.getChannelNumber(), message.data1, message.data2), getSynthEventTimestamp(timestamp));
             } catch(Exception e) {
                 MIMIMod.LOGGER.error("Failed to handle note on: ", e);
             }
@@ -128,7 +128,7 @@ public abstract class AMIMISynth<T extends MIMIChannel> implements AutoCloseable
 
         if(channel != null) {
             try {
-                this.internalSynthReceiver.send(new ShortMessage(ShortMessage.NOTE_OFF, channel.getChannelNumber(), message.data1, 0), getSynthEventTimestamp(timestamp));
+                this.internalSynthReceiver.send(new ExtendedChannelShortMessage(ShortMessage.NOTE_OFF, channel.getChannelNumber(), message.data1, 0), getSynthEventTimestamp(timestamp));
             } catch(Exception e) {
                 MIMIMod.LOGGER.error("Failed to handle note off: ", e);
             }
@@ -152,7 +152,7 @@ public abstract class AMIMISynth<T extends MIMIChannel> implements AutoCloseable
         
         if(channel != null) {
             try {
-                this.internalSynthReceiver.send(new ShortMessage(ShortMessage.CONTROL_CHANGE, channel.getChannelNumber(), message.data1, message.data2), getSynthEventTimestamp(timestamp));
+                this.internalSynthReceiver.send(new ExtendedChannelShortMessage(ShortMessage.CONTROL_CHANGE, channel.getChannelNumber(), message.data1, message.data2), getSynthEventTimestamp(timestamp));
             } catch(Exception e) {
                 MIMIMod.LOGGER.error("Failed to handle control change. Packet: " + message.data1 + " | " + message.data2, e);
             }
@@ -167,7 +167,7 @@ public abstract class AMIMISynth<T extends MIMIChannel> implements AutoCloseable
                 if(message.extData != null) {
                     channel.setPitchBendRange(message.extData);
                 }
-                this.internalSynthReceiver.send(new ShortMessage(ShortMessage.PITCH_BEND, channel.getChannelNumber(), message.data1, message.data2), getSynthEventTimestamp(timestamp));
+                this.internalSynthReceiver.send(new ExtendedChannelShortMessage(ShortMessage.PITCH_BEND, channel.getChannelNumber(), message.data1, message.data2), getSynthEventTimestamp(timestamp));
             } catch(Exception e) {
                 MIMIMod.LOGGER.error("Failed to handle pitch bend. Packet: " + message.data1 + " | " + message.data2, e);
             }

--- a/src/main/java/io/github/tofodroid/mods/mimi/client/midi/synth/ExtendedChannelShortMessage.java
+++ b/src/main/java/io/github/tofodroid/mods/mimi/client/midi/synth/ExtendedChannelShortMessage.java
@@ -1,0 +1,39 @@
+package io.github.tofodroid.mods.mimi.client.midi.synth;
+
+import javax.sound.midi.InvalidMidiDataException;
+import javax.sound.midi.ShortMessage;
+
+/**
+ * A ShortMessage that can address channels beyond the standard MIDI 0-15 range.
+ *
+ * AMIMISynth's internal SoftSynthesizer is configured with 64 "midi channels" to allow
+ * more simultaneous distinct instruments than the MIDI spec's 16-channel limit, but a
+ * plain ShortMessage rejects any channel above 15 in its constructor (InvalidMidiDataException).
+ * The vendored SoftReceiver/SoftMainMixer already special-case ShortMessage.getChannel() > 0xF
+ * (see SoftReceiver#send and SoftMainMixer#processMessage) and route on the value returned by
+ * getChannel() rather than the raw status byte, so overriding getChannel() here is sufficient
+ * to reach the extra channels while still producing a byte-valid message via the super
+ * constructor (built with the channel masked to its low nibble).
+ */
+public class ExtendedChannelShortMessage extends ShortMessage {
+    private final int extendedChannel;
+
+    public ExtendedChannelShortMessage(int command, int channel, int data1, int data2) throws InvalidMidiDataException {
+        super(command, channel & 0xF, data1, data2);
+        this.extendedChannel = channel;
+    }
+
+    @Override
+    public int getChannel() {
+        return extendedChannel;
+    }
+
+    @Override
+    public Object clone() {
+        try {
+            return new ExtendedChannelShortMessage(getCommand(), extendedChannel, getData1(), getData2());
+        } catch (InvalidMidiDataException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/src/main/java/io/github/tofodroid/mods/mimi/common/network/NoteEventPacketHandler.java
+++ b/src/main/java/io/github/tofodroid/mods/mimi/common/network/NoteEventPacketHandler.java
@@ -2,7 +2,11 @@ package io.github.tofodroid.mods.mimi.common.network;
 
 import io.github.tofodroid.mods.mimi.client.ClientProxy;
 import io.github.tofodroid.mods.mimi.common.MIMIMod;
+import io.github.tofodroid.mods.mimi.common.api.event.broadcast.BroadcastEvent;
+import io.github.tofodroid.mods.mimi.server.events.broadcast.producer.transmitter.ATransmitterBroadcastProducer;
+import io.github.tofodroid.mods.mimi.server.events.broadcast.producer.transmitter.ServerTransmitterManager;
 import io.github.tofodroid.mods.mimi.server.events.note.consumer.ServerNoteConsumerManager;
+import io.github.tofodroid.mods.mimi.util.EntityUtils;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 
@@ -10,10 +14,25 @@ public class NoteEventPacketHandler {
     public static void handlePacketServer(final NoteEventPacket message, ServerPlayer sender) {
         if(message != null) {
             ServerNoteConsumerManager.handlePacket(message, true, sender.getUUID(), (ServerLevel)sender.level());
+            relayToTransmitter(message, sender);
+        }
+    }
+
+    // Live-played notes only reach nearby players via ServerNoteConsumerManager above. Broadcasted MIDI files
+    // already reach transmitter-linked consumers (Relay/Receiver/linked instruments) via ATransmitterBroadcastProducer,
+    // but live play never did - mirror what MidiDeviceBroadcastPacketHandler does for external MIDI device input
+    // so a held Transmitter also relays notes played via the in-game instrument GUI/keybinds (see issue #184).
+    private static void relayToTransmitter(final NoteEventPacket message, ServerPlayer sender) {
+        if(EntityUtils.playerHasActiveTransmitter(sender)) {
+            ATransmitterBroadcastProducer musicPlayer = ServerTransmitterManager.getTransmitter(sender.getUUID());
+
+            if(musicPlayer != null) {
+                musicPlayer.broadcast(new BroadcastEvent(message.type, message.channel, message.data1, message.data2, sender.getUUID(), sender.level().dimension(), message.pos, musicPlayer.getBroadcastRange(), message.noteServerTime));
+            }
         }
     }
 
     public static void handlePacketClient(final NoteEventPacket message) {
-        if(MIMIMod.getProxy().isClient()) ((ClientProxy)MIMIMod.getProxy()).getMidiSynth().handlePacket(message); 
+        if(MIMIMod.getProxy().isClient()) ((ClientProxy)MIMIMod.getProxy()).getMidiSynth().handlePacket(message);
     }
 }

--- a/src/main/java/io/github/tofodroid/mods/mimi/neoforge/common/config/ClientConfig.java
+++ b/src/main/java/io/github/tofodroid/mods/mimi/neoforge/common/config/ClientConfig.java
@@ -86,7 +86,12 @@ public class ClientConfig {
         synthBitRate = builder.comment("What bitrate should the built-in midi synthesizer use (bits)? Smaller values may decrease latency but will also decrease quality.","Allowed values: [8,16,24,32]")
             .translation(MIMIMod.MODID + ".config.midi.synth.bitrate")
             .defineInList("synthBitRate", 16, Arrays.asList(8,16,24,32));
-        soundfontPath = builder.comment("Optional full path to an SF2 format SoundFont to be used by the MIDI Synthesizer. See project page for more information.")
+        soundfontPath = builder.comment(
+                "Optional full path to an SF2 format SoundFont to be used by the MIDI Synthesizer. See project page for more information.",
+                "IMPORTANT (Windows users): backslashes (\\) are not allowed as-is in this file. If your path looks like",
+                "C:\\Users\\YourName\\soundfont.sf2 it will silently be reset to blank on next launch. Either use forward",
+                "slashes instead (C:/Users/YourName/soundfont.sf2) or double up every backslash (C:\\\\Users\\\\YourName\\\\soundfont.sf2)."
+            )
             .translation(MIMIMod.MODID + ".config.midi.synth.soundfont.path")
             .define("soundfontPath", "");
         localBufferms = builder.comment("How long to have notes from the server buffer locally before playing. Higher values may decrease stuttering on high-latency connections but will cause redstone effects to be slightly off-tempo.","Allowed values: 0-100")

--- a/src/main/java/io/github/tofodroid/mods/mimi/neoforge/common/config/ClientConfig.java
+++ b/src/main/java/io/github/tofodroid/mods/mimi/neoforge/common/config/ClientConfig.java
@@ -52,7 +52,7 @@ public class ClientConfig {
             .define("audioOutputDevice", "");
         audioDeviceVolume = builder.comment("A multipler used to increase or decrease the base volume of all notes played by MIMI instruments.","Allowed values: 0-10")
             .translation(MIMIMod.MODID + ".config.audio.volume")
-            .defineInRange("audioDeviceVolume",5, 0, 10);
+            .defineInRange("audioDeviceVolume",7, 0, 10);
         builder.pop();
         builder.push(INSTRUMENT_GUI_CATEGORY_NAME);
         keyboardLayout = builder.comment("Instrument GUI keyboard layout for notes. MIMI uses its own layout by default but also supports the layout used by VirtualPiano.net.")

--- a/src/main/java/io/github/tofodroid/mods/mimi/util/MidiNbtDataUtils.java
+++ b/src/main/java/io/github/tofodroid/mods/mimi/util/MidiNbtDataUtils.java
@@ -337,7 +337,9 @@ public abstract class MidiNbtDataUtils {
     public static String getFilteredNotesAsString(ItemStack stack) {
         Byte filterNoteLetter = getFilterNote(stack);
         Byte filterNoteOctave = getFilterOct(stack);
-        String filterNoteString = noteLetterFromNum(filterNoteLetter) + (filterNoteOctave != FILTER_NOTE_OCT_ALL ? filterNoteOctave : "*");
+        // Displayed octave is shifted by -1 from the stored/internal octave so it matches the
+        // scientific pitch notation (middle C = C4, MIDI note 60) used by MIDI editors/DAWs.
+        String filterNoteString = noteLetterFromNum(filterNoteLetter) + (filterNoteOctave != FILTER_NOTE_OCT_ALL ? Integer.valueOf(filterNoteOctave - 1) : "*");
         return "**".equals(filterNoteString) ? "All" : filterNoteString;
     }
 
@@ -346,7 +348,8 @@ public abstract class MidiNbtDataUtils {
 
         if(note != null) {
             Byte filterNoteLetter = Integer.valueOf(note % 12).byteValue();
-            Byte filterNoteOctave = Integer.valueOf(note / 12).byteValue();
+            // -1 so the displayed octave matches scientific pitch notation (middle C = C4, MIDI note 60).
+            Integer filterNoteOctave = Integer.valueOf(note / 12) - 1;
             result = noteLetterFromNum(filterNoteLetter) + filterNoteOctave;
         }
 

--- a/src/main/java/io/github/tofodroid/mods/mimi/util/MidiNbtDataUtils.java
+++ b/src/main/java/io/github/tofodroid/mods/mimi/util/MidiNbtDataUtils.java
@@ -25,7 +25,7 @@ public abstract class MidiNbtDataUtils {
     public static final Byte MAX_BROADCAST_RANGE = 4;
     public static final Byte MAX_INSTRUMENT_VOLUME = 10;
     public static final Integer PERCUSSION_BANK = 120;
-    public static final Byte DEFAULT_INSTRUMENT_VOLUME = 5;
+    public static final Byte DEFAULT_INSTRUMENT_VOLUME = 10;
     public static final Byte MIN_INSTRUMENT_VOLUME = 0;
     public static final Integer ALL_CHANNELS_INT = 65535;
     public static final Integer ALL_BUT_10_CHANNELS_INT = 65023;


### PR DESCRIPTION
Hey tofodroid, I've seen that this repo has gotten pretty inactive and since I also had some trouble, I decided to fix it "myself"...

I know many people don't like AI written code, and I completely understand that. But in this case I think it should be okay, since it only fixed relatively simple bugs and I also wouldn't have had enough time to do it myself. I checked every change and tested it ingame, so I know that it at least won't cause bigger issues then before. That said, here's a summary:

## Summary
A handful of bugs found and fixed while testing on `1.21.1-neo`, several tied to open issues.

- **Guaranteed NPE on synth init failure** - `AMIMISynth`'s catch block called `getVoiceStatus()` on the `internalSynth` reference right after nulling it out, so any audio init failure (e.g. no output device available) crashed with an NPE instead of degrading gracefully. Same fix as #182, rebased onto this branch.
- **Channel-overflow crash under heavy polyphony (#178)** - `AMIMISynth` configures the internal synth with 64 channels, but note events were sent via plain `ShortMessage`, which only accepts channels 0-15 and throws `InvalidMidiDataException` past that. Added `ExtendedChannelShortMessage`, which the vendored `SoftReceiver`/`SoftMainMixer` already had (unused) support for, to carry channel indices up to 63 without losing scheduled-timestamp precision. Verified in a dev client: channel indices up to 63 assigned with zero exceptions under normal Transmitter + live-instrument play (this reproduces easily solo, not just on busy servers).
- **Notes displayed one octave too high** - `MidiNbtDataUtils` computed the displayed octave as `note / 12`, one higher than the scientific pitch notation (middle C = C4) essentially every MIDI editor/DAW uses. Verified by frequency comparison (783 Hz sine = G5 externally, required G6 in-game to match) that only the label was wrong, not the actual synthesized pitch. Fixed the display formulas only; left the underlying filter storage/boundaries untouched so existing configs keep matching the same notes.
- **Transmitter doesn't relay live-played notes (#184)** - Live-played notes (GUI/keybind) reached nearby players but were never forwarded to transmitter-linked consumers (Relay, Receiver, linked instruments) - only MIDI file playback and external MIDI device input went through that path. `NoteEventPacketHandler` now also relays to the player's transmitter producer if they're holding one, mirroring the existing `MidiDeviceBroadcastPacketHandler` logic.
- **Instruments/Transmitter too quiet (#183, #174)** - Both `DEFAULT_INSTRUMENT_VOLUME` and the `audioDeviceVolume` config defaulted to 5/10 and compound multiplicatively (plus note velocity and distance falloff), landing fresh installs around a quarter of max volume. Raised instrument default to 10/10 and the config default to 7/10. Only affects fresh instruments/configs - existing saved values are untouched.
- **`soundfontPath` silently resets to blank (#180)** - Reproduced: an unescaped Windows path (`C:\Users\...`) is invalid TOML, so NeoForge silently resets it to `""` on next launch. There's no in-game setter for this value, so users have no way to know why. Added an explicit warning in the config comment about escaping backslashes or using forward slashes.

## Test plan
All changes tested live in a local dev client (`runClient`) - channel overflow verified via debug logging up to channel 63 with zero exceptions, transmitter relay verified with a Receiver and a separately-linked instrument, octave label verified against 783 Hz reference tone, volume defaults and soundfont warning verified against freshly generated config output.
